### PR TITLE
Support for Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   "dependencies": {
     "@shopify/app": "^3",
     "@shopify/cli": "^3"
-  }
+  },
+  "trustedDependencies": ["@shopify/plugin-cloudflare"]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Adds support for Bun as as package manager (https://github.com/Shopify/cli/pull/3006).

### WHAT is this pull request doing?

- Adds an empty extensions folder, because it's defined as the workspaces folder and Bun crashes if it doesn't exist
- Adds plugin-cloudflare as a trusted dependency in package.json, which is required by Bun to run the postinstall script than downloads the Cloudflare binary

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
