### PR TITLE
Add GraphQL config to extension-only apps

### DIFF
--- a/.graphqlrc.js
+++ b/.graphqlrc.js
@@ -1,0 +1,30 @@
+const fs = require("node:fs");
+
+function getConfig() {
+  const config = {
+    projects: {},
+  };
+
+  let extensions = [];
+  try {
+    extensions = fs.readdirSync("./extensions");
+  } catch {
+    // ignore if no extensions
+  }
+
+  for (const entry of extensions) {
+    const extensionPath = `./extensions/${entry}`;
+    const schema = `${extensionPath}/schema.graphql`;
+    if (!fs.existsSync(schema)) {
+      continue;
+    }
+    config.projects[entry] = {
+      schema,
+      documents: [`${extensionPath}/**/*.graphql`],
+    };
+  }
+
+  return config;
+}
+
+module.exports = getConfig();

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "graphql.vscode-graphql"
+  ]
+}


### PR DESCRIPTION
### WHY are these changes introduced?

To make Functions development easier in extension-only apps. See [this tutorial](https://www.youtube.com/watch?v=jVpvTDv_UFY) for details.

This makes the extension-only template consistent with Remix:
* [.graphqlrc.js](https://github.com/Shopify/shopify-app-template-remix/blob/e143e145ae84df443247c72f4f69d920c0027edf/.graphqlrc.js)
* [extensions.json](https://github.com/Shopify/shopify-app-template-remix/blob/e143e145ae84df443247c72f4f69d920c0027edf/.vscode/extensions.json)

### WHAT is this pull request doing?

Adds a recommendation for the GraphQL VS Code extension and a dynamic GraphQL config.

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
