### PR TITLE
A few things to make this a little easier to understand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Shopify App Template - Extension Only
+# Shopify App Template - Extension only
 
-This is a template for building an [Extension only Shopify app](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app). It contains the basics for building a Shopify app that uses only app extensions.
+This is a template for building an [extension-only Shopify app](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app). It contains the basics for building a Shopify app that uses only app extensions.
 
-This template does not include a server, or the ability to embed a full page in the Shopify Admin. If you want either of these capabilities, choose the [Remix app template](https://github.com/Shopify/shopify-app-template-remix) instead.
+This template doesn't include a server or the ability to embed a page in the Shopify Admin. If you want either of these capabilities, choose the [Remix app template](https://github.com/Shopify/shopify-app-template-remix) instead.
 
 Whether you choose to use this template or another one, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
 


### PR DESCRIPTION
### WHY are these changes introduced?

Whilst opening https://github.com/Shopify/cli/pull/4416, I saw the README in this template could do more to explain this is an extension only app and what that means.

### WHAT is this pull request doing?

Updates the README with:

1. Use extension only verbage more
2. Make the reasons not to use extension only a little clearer and link to the alternative Remix template
3. Update the docs links to be more relevant to extension only apps

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
