### PR TITLE
Gitignore built assets for JS-based extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ logs
 
 # extensions build output
 extensions/*/build
+extensions/*/dist
 
 # lock files
 package-lock.json


### PR DESCRIPTION
Gitignore built assets for JS-based extensions. I shipped this change in https://github.com/Shopify/shopify-app-template-remix/pull/765 but didn't realize we had two repos for the templates.